### PR TITLE
Revert "GHC 9.2.2 -> 9.2.3"

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1655983956,
-        "narHash": "sha256-2h986XafeFMRuIVy3CjfVgzz0cqYbaxfXzcqeCCGqEU=",
+        "lastModified": 1654330348,
+        "narHash": "sha256-jedUKLSqRk/4ToHolO7xnOuztbdDUGCSElvTi5hUGYg=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9b0000f75f6a53c0814264e27ca32f4bddeb15cc",
+        "rev": "6ac93cfc7f0fea4c889a609b18b3333f10091030",
         "type": "github"
       },
       "original": {
@@ -37,11 +37,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1656372800,
-        "narHash": "sha256-1u9SDLXvKix/QejNb2sY2J2QZXnbe/14MnLtn+ln9j0=",
+        "lastModified": 1654230545,
+        "narHash": "sha256-8Vlwf0x8ow6pPOK2a04bT+pxIeRnM1+O0Xv9/CuDzRs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "020c74014b9e2fa905bb4059c979965816cd9118",
+        "rev": "236cc2971ac72acd90f0ae3a797f9f83098b17ec",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
           };
           ghc92 = {
             root = ./.;
-            haskellPackages = pkgs.haskell.packages.ghc923; # Needed for `UnconsSymbol`
+            haskellPackages = pkgs.haskell.packages.ghc922; # Needed for `UnconsSymbol`
             buildTools = hp:
               let
                 # https://github.com/NixOS/nixpkgs/issues/140774 reoccurs in GHC 9.2
@@ -51,10 +51,11 @@
               inherit (inputs) relude;
             };
             overrides = self: super: with pkgs.haskell.lib; {
-              relude = dontCheck super.relude; # Not in nixpkgs for GHC 9.2
-              retry = dontCheck super.retry; # Fails on 9.2 / macOS M1
-              http2 = dontCheck super.http2; # Fails on 9.2 / macOS M1
-              streaming-commons = dontCheck super.streaming-commons; # Fails on 9.2 / macOS M1
+              # All these below are for GHC 9.2 compat.
+              relude = dontCheck super.relude;
+              retry = dontCheck super.retry;
+              http2 = dontCheck super.http2; # Fails on darwin
+              streaming-commons = dontCheck super.streaming-commons; # Fails on darwin
             };
           };
         };


### PR DESCRIPTION
Reverts EmaApps/ema#109

Because nix shell is broken. cf. build failures in https://github.com/EmaApps/ema/pull/111